### PR TITLE
Story 15: Merchant Invoice Show Page

### DIFF
--- a/app/controllers/merchant_invoices_controller.rb
+++ b/app/controllers/merchant_invoices_controller.rb
@@ -4,6 +4,7 @@ class MerchantInvoicesController < ApplicationController
   end
 
   def show
-    
+    @merchant = Merchant.find(params[:merchant_id])
+    @invoice = Invoice.find(params[:id])
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -12,7 +12,6 @@ class Invoice < ApplicationRecord
   end
 
   def formatted_date
-    created_at.strftime("%A, %B %d, %Y")
+    created_at.strftime("%A, %B %-e, %Y")
   end
-
 end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -1,0 +1,13 @@
+<%= render partial: "merchants/header", locals: {merchant: @merchant} %>
+
+<div id="merchant_invoice_info">
+  <h1>Invoice #<%= @invoice.id %></h1>
+
+  <p><b>Status: </b><%= @invoice.status.titleize %></p>
+  <p><b>Created on: </b><%= @invoice.formatted_date %></p>
+
+  <div id="merchant_invoice_customer_info">
+    <h2>Customer:</h2>
+    <p><%= @invoice.customer.full_name %></p>
+  </div>
+</div>

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe "Merchant Invoices Index page", type: :feature do
 
     it "each invoice.id links to its merchant invoice show page" do
       visit merchant_invoices_path(@merchant_1)
-      save_and_open_page
 
       within("div#merchant_invoices") do
         expect(page).to have_link("#{@invoice_1.id}", href: merchant_invoice_path(@merchant_1, @invoice_1))

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Merchant Invoice Show Page", type: :feature do
     InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 10, unit_price: 66747, status: 'shipped')
     
     # @invoice_2 has one item from @merchant_1 and one item from @merchant_2
-    @invoice_2 = @customer_2.invoices.create!(status: 'in progress', created_at: Time.new(2001))
+    @invoice_2 = @customer_2.invoices.create!(status: 'completed', created_at: Time.new(2001))
     InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_3.id, quantity: 9, unit_price: 23324, status: 'pending')
     InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_4.id, quantity: 9, unit_price: 76941, status: 'packaged')
 
@@ -41,13 +41,13 @@ RSpec.describe "Merchant Invoice Show Page", type: :feature do
       visit merchant_invoice_path(@merchant_1, @invoice_1)
       within("div#merchant_invoice_info") do
         expect(page).to have_content("Invoice ##{@invoice_1.id}")
-        expect(page).to have_content("Status: #{@invoice_1.status_formatted}")
+        expect(page).to have_content("Status: In Progress")
       end
 
       visit merchant_invoice_path(@merchant_1, @invoice_2)
       within("div#merchant_invoice_info") do
         expect(page).to have_content("Invoice ##{@invoice_2.id}")
-        expect(page).to have_content("Status: #{@invoice_2.status_formatted}")
+        expect(page).to have_content("Status: Completed")
       end
     end
     
@@ -59,7 +59,7 @@ RSpec.describe "Merchant Invoice Show Page", type: :feature do
 
       visit merchant_invoice_path(@merchant_1, @invoice_2)
       within("div#merchant_invoice_info") do
-        expect(page).to have_content("Created on: Monday, January 1, 2000")
+        expect(page).to have_content("Created on: Monday, January 1, 2001")
       end
     end
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe "Merchant Invoice Show Page", type: :feature do
+  before :each do
+    # Customers
+    @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Ondricka')
+    @customer_2 = Customer.create!(first_name: 'Cecelia', last_name: 'Osinski')
+    @customer_3 = Customer.create!(first_name: 'Mariah', last_name: 'Toy')
+    @customer_4 = Customer.create!(first_name: 'Leanna', last_name: 'Braun')
+
+    # Merchants
+    @merchant_1 = Merchant.create!(name: 'Schroeder-Jerde')
+    @merchant_2 = Merchant.create!(name: 'Rempel and Jones')
+
+    # Items
+    # @merchant_1's items
+    @item_1 = @merchant_1.items.create!(name: 'Qui Esse', description: 'Nihil autem sit odio inventore deleniti', unit_price: 75107)
+    @item_2 = @merchant_1.items.create!(name: 'Autem Minima', description: 'Cumque consequuntur ad', unit_price: 67076)
+    @item_3 = @merchant_1.items.create!(name: 'Ea Voluptatum', description: 'Sunt officia eum qui molestiae', unit_price: 32301)
+    # @merchant_2's item
+    @item_4 = @merchant_2.items.create!(name: 'Nemo Facere', description: 'Sunt eum id eius magni consequuntur delectus veritatis', unit_price: 4291)
+
+    # Invoices
+    # @invoice_1 has two items from @merchant_1
+    @invoice_1 = @customer_1.invoices.create!(status: 'in progress', created_at: Time.new(2000))
+    InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 5, unit_price: 13635, status: 'packaged')
+    InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 10, unit_price: 66747, status: 'shipped')
+    
+    # @invoice_2 has one item from @merchant_1 and one item from @merchant_2
+    @invoice_2 = @customer_2.invoices.create!(status: 'in progress', created_at: Time.new(2001))
+    InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_3.id, quantity: 9, unit_price: 23324, status: 'pending')
+    InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_4.id, quantity: 9, unit_price: 76941, status: 'packaged')
+
+    # @invoice 3 has one item from @merchant_2
+    @invoice_3 = @customer_3.invoices.create!(status: 'cancelled', created_at: Time.new(2003))
+    InvoiceItem.create!(invoice_id: @invoice_3.id, item_id: @item_4.id, quantity: 12, unit_price: 34873, status: 'packaged')
+  end
+
+  describe "when I visit a merchant's invoice show page (/merchants/:merchant_id/invoices/:invoice_id)" do
+    it "I see that invoice's id and status" do
+      visit merchant_invoice_path(@merchant_1, @invoice_1)
+      within("div#merchant_invoice_info") do
+        expect(page).to have_content("Invoice ##{@invoice_1.id}")
+        expect(page).to have_content("Status: #{@invoice_1.status_formatted}")
+      end
+
+      visit merchant_invoice_path(@merchant_1, @invoice_2)
+      within("div#merchant_invoice_info") do
+        expect(page).to have_content("Invoice ##{@invoice_2.id}")
+        expect(page).to have_content("Status: #{@invoice_2.status_formatted}")
+      end
+    end
+    
+    it "I see the invoice's created_at date in the format 'Monday, July 18, 2019'" do
+      visit merchant_invoice_path(@merchant_1, @invoice_1)
+      within("div#merchant_invoice_info") do
+        expect(page).to have_content("Created on: Saturday, January 1, 2000")
+      end
+
+      visit merchant_invoice_path(@merchant_1, @invoice_2)
+      within("div#merchant_invoice_info") do
+        expect(page).to have_content("Created on: Monday, January 1, 2000")
+      end
+    end
+
+    it "I see the customer's first and last name" do
+      visit merchant_invoice_path(@merchant_1, @invoice_1)
+      within("div#merchant_invoice_customer_info") do
+        expect(page).to have_content(@customer_1.first_name)
+        expect(page).to have_content(@customer_1.last_name)
+      end
+
+      visit merchant_invoice_path(@merchant_1, @invoice_2)
+      within("div#merchant_invoice_customer_info") do
+        expect(page).to have_content(@customer_2.first_name)
+        expect(page).to have_content(@customer_2.last_name)
+      end
+    end
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -163,39 +163,24 @@ RSpec.describe Merchant, type: :model do
 
         expect(result).to match_array(expected_items)
       end
-    
+
       it "also returns the invoice_id for each associated item" do
         result = @merchant_1.items_ready
         expect(result[0].invoice_id).to eq(@invoice_3.id)
         expect(result[1].invoice_id).to eq(@invoice_4.id)
       end
-    
-      describe "#items_ready" do
-        it "returns all items that have been ordered, not shipped, and from an uncancelled invoice" do
-          expected_items = [@item_3, @item_4]
-          result = @merchant_1.items_ready
 
-          expect(result).to match_array(expected_items)
-        end
+      it "sorts by invoice creation date, oldest first" do
+        result = @merchant_1.items_ready
+        
+        expect(result.first.created_at_time < result.last.created_at_time).to be true
+      end
 
-        it "also returns the invoice_id for each associated item" do
-          result = @merchant_1.items_ready
-          expect(result[0].invoice_id).to eq(@invoice_3.id)
-          expect(result[1].invoice_id).to eq(@invoice_4.id)
-        end
+      it "returns a formatted string of the invoice creation date" do
+        result = @merchant_1.items_ready
 
-        it "sorts by invoice creation date, oldest first" do
-          result = @merchant_1.items_ready
-          
-          expect(result.first.created_at_time < result.last.created_at_time).to be true
-        end
-
-        it "returns a formatted string of the invoice creation date" do
-          result = @merchant_1.items_ready
-
-          expect(result[0].invoice_created_at).to eq("Saturday, January 1, 2000")
-          expect(result[1].invoice_created_at).to eq("Sunday, January 1, 2023")
-        end
+        expect(result[0].invoice_created_at).to eq("Saturday, January 1, 2000")
+        expect(result[1].invoice_created_at).to eq("Sunday, January 1, 2023")
       end
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -147,7 +147,8 @@ RSpec.describe Merchant, type: :model do
         merch_1_distinct_invoices = [@invoice_1, @invoice_2, @invoice_3, @invoice_4, @invoice_5, @invoice_6, @invoice_7, @invoice_8, @invoice_9, @invoice_10, @invoice_11, @invoice_12]
 
         expect(@merchant_1.distinct_invoices).to match_array(merch_1_distinct_invoices)
-
+      end
+    end
     
     describe "#items_ready" do
       it "returns all items that have been ordered, not shipped, and from an uncancelled invoice" do


### PR DESCRIPTION
# Implements/Fixes

This PR creates a Merchant Index Show page and completes User Story 15. 

```
15. Merchant Invoice Show Page

As a merchant
When I visit my merchant's invoice show page (/merchants/:merchant_id/invoices/:invoice_id)
Then I see information related to that invoice including:
- Invoice id
- Invoice status
- Invoice created_at date in the format "Monday, July 18, 2019"
- Customer first and last name
```
I also threw in a few small bug fixes and changes to methods, where necessary. For example, I changed the date display method for the `Invoice` model. 

Before, it would display a `0` for single digit month days (ie, `January 01` instead of `January 1`)

### Issues Closes
- [x] #61 

## Checklists
### Necessary checkmarks
- [x] All Tests are Passing
- [x] The code will run locally

### Type of change
- [x] New feature
- [x] Bug Fix

### Check the correct boxes

- [x] This broke nothing
- [x] This broke some stuff
- [x] This broke everything

### Testing Changes

- [ ] No Tests have been changed
- [x] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

### Checklist:

- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

## Relevant Screenshots

(REQUIRED)Please Include a link to a gif of your feelings about this branch

Link:
