### PR TITLE
Adds testing for US_28

### DIFF
--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
   end
 
   describe "When I visit the admin merchants index" do 
-    # US 27
+    # US 27 & 28
     it "Then next to each merchant name I see a button to disable or enable that merchant." do 
 
       visit admin_merchants_path
@@ -67,6 +67,15 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
 
       within "#disabled_merchants" do 
         expect(page).to have_button("Enable #{@merchant_1.name}")
+        expect(page).to_not have_button("Enable #{@merchant_3.name}")
+        expect(page).to have_button("Enable #{@merchant_2.name}")
+      end
+
+
+      within "#enabled_merchants" do
+        expect(page).to have_button("Disable #{@merchant_3.name}")
+        expect(page).not_to have_button("Disable #{@merchant_2.name}")
+        expect(page).not_to have_button("Disable #{@merchant_1.name}")
       end
     end
 


### PR DESCRIPTION
US_28
As an admin,
When I visit the admin merchants index (/admin/merchants)
Then I see two sections, one for "Enabled Merchants" and one for "Disabled Merchants"
And I see that each Merchant is listed in the appropriate section


__x__ Wrote Tests __x__ Implemented __x__ Reviewed

Neccesary checkmarks:

    [x] All Tests are Passing

    [x] The code will run locally

Type of change

    [x] New feature
    [] Bug Fix

Implements/Fixes:

    description closes #46 

Check the correct boxes

    [x] This broke nothing
    [] This broke some stuff
    [] This broke everything

Testing Changes

    [] No Tests have been changed
    [x] Some Tests have been changed (added tests for US_28)
    [] All of the Tests have been changed(Please describe what in the world happened)

Checklist:

    [X] My code has no unused/commented out code
    [x] I have reviewed my code
    [] I have commented my code, particularly in hard-to-understand areas
    [x] I have fully tested my code

(REQUIRED)Please Include a link to a gif of your feelings about this branch

Link: 
![image](https://github.com/z-fitch/little-shop-7/assets/64923238/55c11b1b-29dd-43d6-bc48-a11c6428f2bf)

